### PR TITLE
feat(tutorials): add dedicated tutorials section for featured partner

### DIFF
--- a/app/tools/[category]/tool-category.client.tsx
+++ b/app/tools/[category]/tool-category.client.tsx
@@ -132,6 +132,33 @@ export function ToolCategoryClient({ category }: ToolCategoryClientProps) {
                 </div>
               </div>
             </div>
+
+            {/* Dedicated Tutorials for Featured Partner */}
+            <div className="space-y-4">
+              <h4 className="text-sm font-semibold uppercase tracking-wider text-zinc-400">
+                Dedicated Tutorials (Featured Partner Benefit)
+              </h4>
+              <div className="grid gap-4 md:grid-cols-3">
+                {[1, 2, 3].map((num) => (
+                  <div
+                    key={num}
+                    className="rounded-2xl border border-dashed border-zinc-700 bg-zinc-900/30 p-5 transition hover:border-zinc-600"
+                  >
+                    <div className="flex items-center gap-3 mb-3">
+                      <div className="w-8 h-8 rounded-lg bg-[#14F195]/10 flex items-center justify-center text-[#14F195] text-sm font-bold">
+                        {num}
+                      </div>
+                      <span className="text-xs text-zinc-500 uppercase tracking-wider">Tutorial {num}</span>
+                    </div>
+                    <h5 className="text-white font-medium mb-1">Tutorial Slot {num}</h5>
+                    <p className="text-xs text-zinc-500">A dedicated tutorial created for the Featured Partner&apos;s product.</p>
+                  </div>
+                ))}
+              </div>
+              <p className="text-xs text-zinc-500 text-center">
+                Featured Partners get dedicated tutorials on this page and inside the main tutorials as well showcasing their product integration with Solana development.
+              </p>
+            </div>
           </section>
 
           {/* Other Tools Section */}

--- a/components/route-guard.tsx
+++ b/components/route-guard.tsx
@@ -13,6 +13,8 @@ const PROTECTED_ROUTES = [
   "/projects",
   "/challenges",
   "/learn",
+  "/tools",
+  "/partner",
   "/test-auth",
   "/dashboard",
   "/admin",
@@ -24,12 +26,6 @@ const ROUTE_CONFIGS = {
     description:
       "Access interactive Solana games and challenges to test your skills.",
     icon: "🎮",
-  },
-  "/jobs": {
-    title: "💼 Job Board",
-    description:
-      "Explore exclusive Solana development opportunities and career paths.",
-    icon: "💼",
   },
   "/modules": {
     title: "🎓 Learning Modules",
@@ -53,6 +49,18 @@ const ROUTE_CONFIGS = {
     description:
       "Access comprehensive Solana learning materials and documentation.",
     icon: "📚",
+  },
+  "/tools": {
+    title: "🛠️ Developer Tools",
+    description:
+      "Explore essential Solana developer tools and infrastructure.",
+    icon: "🛠️",
+  },
+  "/partner": {
+    title: "🤝 Partnership",
+    description:
+      "Learn about partnership opportunities with LearnSol.",
+    icon: "🤝",
   },
   "/test-auth": {
     title: "🔐 Authentication Test",

--- a/data/tools-data.ts
+++ b/data/tools-data.ts
@@ -38,12 +38,17 @@ const createPlaceholderFeaturedTool = (): FeaturedTool => ({
   logo: "/placeholder.jpg",
   website: "#",
   features: [
-    "Premium placement",
-    "AI Assistant recommendations",
-    "Tutorial mentions",
-    "Category exclusivity",
+    "References in all related tutorials",
+    "AI bot recommends your tool to learners",
+    "Default tool in upcoming video content",
+    "3 dedicated tutorials for your product",
+    "Much more on your demand!",
   ],
-  stats: [{ label: "Status", value: "Open" }],
+  stats: [
+    { label: "Status", value: "Open" },
+    { label: "Tutorials", value: "Exclusive" },
+    { label: "Promotion", value: "Maximum" },
+  ],
 });
 
 // Placeholder tools for "Other Providers" section


### PR DESCRIPTION
This pull request introduces a new "Dedicated Tutorials" section for Featured Partners in the tools category page and updates the route guard configuration to include new protected routes and improved descriptions. It also enhances the featured tool data model with additional features and stats for partners.

**UI Improvements for Featured Partners:**
* Added a "Dedicated Tutorials (Featured Partner Benefit)" section to the `ToolCategoryClient` component, displaying three dedicated tutorial slots with descriptions and a benefit note for Featured Partners. ([app/tools/[category]/tool-category.client.tsxR135-R161](diffhunk://#diff-476fb1c1913ce6dbbb2bd4a60f5d3e6a025072a7cc8b7ab5130d349783d65942R135-R161))

**Route Guard Configuration Updates:**
* Added `/tools` and `/partner` to the `PROTECTED_ROUTES` array to ensure these routes require authentication.
* Added route configurations for `/tools` and `/partner`, including titles, descriptions, and icons for each.
* Removed `/jobs` route configuration, cleaning up unused or deprecated routes.

**Featured Tool Data Model Enhancements:**
* Updated the `FeaturedTool` placeholder to include new features such as dedicated tutorials, AI recommendations, video content integration, and expanded promotional stats.