### PR TITLE
feat: enhance SEO and metadata across the application; update titles,…

### DIFF
--- a/app/challenges/page.tsx
+++ b/app/challenges/page.tsx
@@ -6,13 +6,25 @@ import {
   defaultTwitterImage,
 } from "@/lib/seo";
 
-const title = "Solana Coding Challenges";
+const title = "Solana Coding Challenges | 30-Day Rust & Solana Practice";
 const description =
-  "Tackle a 30-day Solana and Rust challenge track with progressive prompts and upcoming interactive tooling.";
+  "Sharpen your Solana skills with daily coding challenges. 30-day tracks covering Rust, Anchor, and Solana smart contracts. Perfect for learning Solana programming.";
+
+const challengeKeywords = [
+  "solana coding challenges",
+  "solana practice",
+  "rust solana exercises",
+  "anchor challenges",
+  "solana programming practice",
+  "learn rust solana",
+  "solana developer exercises",
+  "blockchain coding challenges",
+];
 
 export const metadata: Metadata = {
   title,
   description,
+  keywords: challengeKeywords,
   alternates: {
     canonical: createCanonical("/challenges"),
   },

--- a/app/games/page.tsx
+++ b/app/games/page.tsx
@@ -6,13 +6,24 @@ import {
   defaultTwitterImage,
 } from "@/lib/seo";
 
-const title = "Solana Learning Games";
+const title = "Learn Solana Through Games | Interactive Blockchain Tutorials";
 const description =
-  "Play interactive Solana games that reward learning with NFTs and tracked progression.";
+  "Master Solana concepts through fun, interactive games. Learn blockchain, transactions, accounts, and smart contracts while playing. Earn NFTs as you progress.";
+
+const gamesKeywords = [
+  "solana games",
+  "learn solana games",
+  "blockchain learning games",
+  "interactive solana tutorial",
+  "solana education games",
+  "web3 learning games",
+  "gamified blockchain learning",
+];
 
 export const metadata: Metadata = {
   title,
   description,
+  keywords: gamesKeywords,
   alternates: {
     canonical: createCanonical("/games"),
   },

--- a/app/home-page.client.tsx
+++ b/app/home-page.client.tsx
@@ -35,12 +35,12 @@ export function HomePageClient() {
             <div className="flex flex-col items-center justify-center gap-4 sm:gap-6 px-4 text-center">
               <div className="flex flex-wrap items-baseline justify-center gap-4 md:gap-8">
                 <h1 className="text-4xl sm:text-6xl md:text-7xl lg:text-8xl font-semibold text-white tracking-tighter leading-none">
-                  master
+                  <span className="sr-only">Learn Solana - </span>master
                 </h1>
                 <div className="flex items-center">
                   <Image
                     src="/solanaMain.png"
-                    alt="Solana Logo"
+                    alt="Solana blockchain development"
                     width={120}
                     height={120}
                     className="object-contain h-10 sm:h-14 md:h-[60px] w-auto"
@@ -48,7 +48,7 @@ export function HomePageClient() {
                   />
                 </div>
               </div>
-              <p className="text-base sm:text-lg md:text-2xl lg:text-3xl text-white/70 tracking-tighter">
+              <p className="text-base sm:text-lg md:text-2xl lg:text-3xl text-white/70 tracking-tighter italic">
                 without any hassle.
               </p>
             </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -32,10 +32,12 @@ const spaceGrotesk = Space_Grotesk({
 
 const organizationJsonLd = {
   "@context": "https://schema.org",
-  "@type": "Organization",
+  "@type": "EducationalOrganization",
   name: "learn.sol",
+  alternateName: "Learn Solana",
   url: siteUrl,
   logo: `${siteUrl}/opengraph-image.png`,
+  description: "Free Solana development courses, tutorials, and coding challenges",
   sameAs: ["https://x.com/learndotsol", "https://github.com/learn-solana"],
   contactPoint: [
     {
@@ -44,6 +46,41 @@ const organizationJsonLd = {
       email: "raghav@learnsol.site",
     },
   ],
+};
+
+const courseJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Course",
+  name: "Learn Solana Development",
+  description: "Free comprehensive Solana development course covering blockchain fundamentals, Rust programming, Anchor framework, and building dApps",
+  provider: {
+    "@type": "EducationalOrganization",
+    name: "learn.sol",
+    url: siteUrl,
+  },
+  educationalLevel: "Beginner to Advanced",
+  isAccessibleForFree: true,
+  inLanguage: "en",
+  coursePrerequisites: "Basic programming knowledge",
+  teaches: ["Solana Development", "Rust Programming", "Smart Contracts", "Anchor Framework", "Web3 Development"],
+  hasCourseInstance: {
+    "@type": "CourseInstance",
+    courseMode: "online",
+    courseWorkload: "PT40H",
+  },
+};
+
+const websiteJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  name: "learn.sol",
+  alternateName: "Learn Solana",
+  url: siteUrl,
+  potentialAction: {
+    "@type": "SearchAction",
+    target: `${siteUrl}/search?q={search_term_string}`,
+    "query-input": "required name=search_term_string",
+  },
 };
 
 export const viewport: Viewport = {
@@ -58,23 +95,23 @@ export const viewport: Viewport = {
 export const metadata: Metadata = {
   metadataBase,
   title: {
-    default: "Learn Solana",
-    template: "%s | Learn Solana",
+    default: "Learn Solana | Free Solana Development Course",
+    template: "%s | learn.sol",
   },
   description:
-    "Learn solana through courses, games and coding challenges at learn.sol",
+    "Learn Solana development for free. Master Solana programming, Rust, Anchor framework through interactive courses, games, and coding challenges. The best way to learn Solana.",
   keywords: courseKeywords,
-  applicationName: "Learn Solana",
+  applicationName: "learn.sol",
   authors: [{ name: "learn.sol Team" }],
   alternates: {
     canonical: siteUrl,
   },
   openGraph: {
-    title: "Learn Solana",
+    title: "Learn Solana | Free Solana Development Course",
     description:
-      "Learn solana through courses, games and coding challenges at learn.sol",
+      "Learn Solana development for free. Master Solana programming through interactive courses, games, and challenges.",
     url: siteUrl,
-    siteName: "learn.sol",
+    siteName: "learn.sol, Learn Solana Development",
     locale: "en_US",
     images: [defaultOpenGraphImage],
     type: "website",
@@ -83,9 +120,9 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     site: "@learndotsol",
     creator: "@Some1UKnow25",
-    title: "Learn Solana",
+    title: "Learn Solana | Free Development Course",
     description:
-      "Learn solana through courses, games and coding challenges at learn.sol",
+      "Learn Solana development for free through interactive courses, games, and coding challenges.",
     images: [defaultTwitterImage],
   },
   robots: {
@@ -99,7 +136,7 @@ export const metadata: Metadata = {
       "max-image-preview": "large",
     },
   },
-  category: "technology",
+  category: "education",
 };
 
 export default async function RootLayout({
@@ -122,6 +159,20 @@ export default async function RootLayout({
           strategy="beforeInteractive"
         >
           {JSON.stringify(organizationJsonLd)}
+        </Script>
+        <Script
+          id="jsonld-course"
+          type="application/ld+json"
+          strategy="beforeInteractive"
+        >
+          {JSON.stringify(courseJsonLd)}
+        </Script>
+        <Script
+          id="jsonld-website"
+          type="application/ld+json"
+          strategy="beforeInteractive"
+        >
+          {JSON.stringify(websiteJsonLd)}
         </Script>
         {process.env.NEXT_PUBLIC_ENABLE_REACT_SCAN && (
           // react-scan performance analyzer (only enabled when explicitly requested)

--- a/app/modules/page.tsx
+++ b/app/modules/page.tsx
@@ -6,13 +6,27 @@ import {
   defaultTwitterImage,
 } from "@/lib/seo";
 
-const title = "Solana Modules Library";
+const title = "Free Solana Course | Learn Solana Development Step-by-Step";
 const description =
-  "Browse structured Solana learning modules spanning fundamentals, tooling, and on-chain program design.";
+  "Start your Solana developer journey with our structured course. Learn Solana fundamentals, Rust programming, Anchor framework, and build real dApps from scratch.";
+
+const moduleKeywords = [
+  "solana course",
+  "solana courses",
+  "free solana course",
+  "solana development course",
+  "learn solana online",
+  "solana tutorial",
+  "solana developer course",
+  "solana programming course",
+  "anchor framework course",
+  "rust solana course",
+];
 
 export const metadata: Metadata = {
   title,
   description,
+  keywords: moduleKeywords,
   alternates: {
     canonical: createCanonical("/modules"),
   },

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,14 +7,22 @@ import {
   defaultTwitterImage,
 } from "@/lib/seo";
 
-const title = "Learn Solana";
+const title = "Learn Solana | Free Solana Development Course & Tutorials";
 const description =
-  "Master Solana development with curated courses, interactive games, and coding challenges at learn.sol.";
+  "Learn Solana development from scratch with our free course. Master Solana programming, smart contracts, Rust & Anchor through interactive tutorials, games, and coding challenges.";
+
+const homeKeywords = [
+  ...courseKeywords,
+  "solana for beginners",
+  "blockchain development course",
+  "web3 development tutorial",
+  "learn blockchain programming",
+];
 
 export const metadata: Metadata = {
   title,
   description,
-  keywords: courseKeywords,
+  keywords: homeKeywords,
   alternates: {
     canonical: createCanonical("/"),
   },

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -6,13 +6,25 @@ import {
   defaultTwitterImage,
 } from "@/lib/seo";
 
-const title = "Build Projects on Solana";
+const title = "Build Solana Projects | Hands-On Solana Development Tutorials";
 const description =
-  "Explore hands-on Solana projects with guidance, courses, and progression tracking.";
+  "Learn Solana by building real projects. Step-by-step tutorials for dApps, NFT marketplaces, DeFi protocols, and more. The best way to learn Solana development.";
+
+const projectKeywords = [
+  "solana projects",
+  "build on solana",
+  "solana dapp tutorial",
+  "solana nft project",
+  "solana defi tutorial",
+  "solana project ideas",
+  "hands-on solana",
+  "solana portfolio projects",
+];
 
 export const metadata: Metadata = {
   title,
   description,
+  keywords: projectKeywords,
   alternates: {
     canonical: createCanonical("/projects"),
   },

--- a/components/home/learn-solana-section.tsx
+++ b/components/home/learn-solana-section.tsx
@@ -17,52 +17,52 @@ type Tile = {
 const tiles: Tile[] = [
   {
     id: "modules",
-    title: "Master the Fundamentals",
+    title: "Free Solana Course",
     href: "/modules",
     icon: "/solanaLogo.png",
-    eyebrow: "Structured lessons",
-    blurb: "Start with core concepts, step-by-step projects, and real code you can ship. Perfect for developers who want to build for devnet today.",
+    eyebrow: "Structured learning path",
+    blurb: "Learn Solana development from scratch. Our free course covers blockchain fundamentals, Rust programming, Anchor framework, and building real dApps step-by-step.",
     tone: "green",
   },
   {
     id: "games",
-    title: "Play to earn NFTs",
+    title: "Learn Solana with Games",
     href: "/games",
     icon: "/solanaLogo.png",
-    eyebrow: "Interactive games",
-    blurb: "Hands-on mini-games that teach web3 primitives. Complete levels, claim rewards, and internalize tricky concepts by doing.",
+    eyebrow: "Interactive tutorials",
+    blurb: "Master Solana concepts through fun, interactive games. Learn transactions, accounts, and smart contracts while earning NFTs for your progress.",
     tone: "cyan",
   },
   {
     id: "tools",
-    title: "Your Dev Stack, Sorted",
+    title: "Solana Developer Tools",
     href: "/tools",
     icon: "/solanaLogo.png",
-    eyebrow: "Essential infrastructure",
-    blurb: "RPCs, wallets, explorers, and more. Curated tools that real builders use. Skip the research and start shipping faster.",
+    eyebrow: "Essential dev stack",
+    blurb: "Discover the best Solana development tools. RPCs, wallets, explorers, testing frameworks - everything you need to build on Solana.",
     tone: "purple",
   },
   {
     id: "challenges",
-    title: "Daily Code Challenges",
+    title: "Solana Coding Challenges",
     href: "/challenges",
     icon: "/rust-2.png",
-    eyebrow: "30-day tracks",
-    blurb: "Short, intense prompts that improve your Rust and Solana instincts. Come for the grind, stay for the breakthroughs.",
+    eyebrow: "30-day practice tracks",
+    blurb: "Sharpen your Solana skills with daily coding challenges. Practice Rust and Anchor development with progressive difficulty challenges.",
     tone: "amber",
   },
 ];
 
 export function LearnSolanaSection() {
   return (
-    <section aria-labelledby="learn-solana" className="container relative z-10 -mt-6 md:-mt-10 pb-8 md:pb-12">
+    <section aria-labelledby="learn-solana-courses" className="container relative z-10 -mt-6 md:-mt-10 pb-8 md:pb-12">
       <div className="mb-6 md:mb-8 text-center">
-        <div className="text-xs tracking-[0.25em] text-zinc-400">[LEARN SOLANA]</div>
-        <h2 id="learn-solana" className="mt-2 text-2xl sm:text-3xl font-semibold tracking-tight">
-          Pick your path
+        <div className="text-xs tracking-[0.25em] text-zinc-400">[FREE SOLANA DEVELOPMENT COURSE]</div>
+        <h2 id="learn-solana-courses" className="mt-2 text-2xl sm:text-3xl font-semibold tracking-tight">
+          Start Learning Solana Today
         </h2>
         <p className="mt-2 max-w-2xl mx-auto text-sm text-zinc-400">
-          Choose a focused track — each tile contains a clear outcome and a tiny dare: click it and prove you can ship.
+          Choose your learning path. Master Solana development through our free course, interactive games, and daily coding challenges.
         </p>
       </div>
 
@@ -70,13 +70,13 @@ export function LearnSolanaSection() {
         {tiles.map((t) => (
           <Link key={t.id} href={t.href} className="group" aria-label={t.title}>
             <Card
-              className={`relative overflow-hidden rounded-3xl border border-white/6 bg-gradient-to-b from-white/2 to-transparent transition-transform duration-300 hover:scale-[1.02] hover:shadow-[0_30px_80px_rgba(0,0,0,0.6)]`}
+              className={`relative overflow-hidden rounded-3xl border border-white/6 bg-linear-to-b from-white/2 to-transparent transition-transform duration-300 hover:scale-[1.02] hover:shadow-[0_30px_80px_rgba(0,0,0,0.6)]`}
             >
               <div className="absolute -inset-1 opacity-0 group-hover:opacity-100 transition-opacity duration-500 pointer-events-none">
-                <div className="w-full h-full bg-gradient-to-br from-white/3 to-transparent mix-blend-screen" />
+                <div className="w-full h-full bg-linear-to-br from-white/3 to-transparent mix-blend-screen" />
               </div>
 
-              <CardContent className="p-5 md:p-8 flex min-h-[15rem] md:min-h-[16rem] items-stretch gap-4 md:gap-6">
+              <CardContent className="p-5 md:p-8 flex min-h-60 md:min-h-64 items-stretch gap-4 md:gap-6">
                 <div className="flex flex-col justify-between w-full">
                   <div className="flex items-start justify-between gap-3 sm:gap-4">
                     <div>

--- a/components/route-guard.tsx
+++ b/components/route-guard.tsx
@@ -120,7 +120,7 @@ export function RouteGuard({ children }: RouteGuardProps) {
     return (
       <div className="min-h-screen flex items-center justify-center relative overflow-hidden">
         {/* Dark background matching main page */}
-        <div className="absolute inset-0 bg-gradient-to-br from-gray-900 via-slate-900 to-gray-900" />
+        <div className="absolute inset-0 bg-linear-to-br from-gray-900 via-slate-900 to-gray-900" />
         <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_50%,rgba(6,182,212,0.1),transparent_50%)]" />
         
         <div className="relative z-10 bg-gray-900/40 backdrop-blur-xl border border-gray-700/50 rounded-2xl p-8 shadow-2xl">
@@ -147,7 +147,7 @@ export function RouteGuard({ children }: RouteGuardProps) {
       </div>
 
       {/* Very light dark themed overlay */}
-      <div className="absolute inset-0 bg-gradient-to-br from-gray-900/20 via-slate-900/15 to-gray-900/20" />
+      <div className="absolute inset-0 bg-linear-to-br from-gray-900/20 via-slate-900/15 to-gray-900/20" />
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_30%_40%,rgba(6,182,212,0.08),transparent_50%)]" />
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_70%_80%,rgba(14,165,233,0.05),transparent_50%)]" />
 
@@ -159,7 +159,7 @@ export function RouteGuard({ children }: RouteGuardProps) {
             <Button
               onClick={handleLogin}
               disabled={isConnecting}
-              className="h-12 px-6 bg-gradient-to-r from-teal-400 to-emerald-500 hover:from-teal-300 hover:to-emerald-400 text-gray-900 font-medium rounded-xl border border-white/10 shadow-lg transition-all duration-200 hover:shadow-teal-400/25 hover:scale-[1.02] disabled:hover:scale-100 flex items-center gap-2"
+              className="h-12 px-6 bg-linear-to-r from-teal-400 to-emerald-500 hover:from-teal-300 hover:to-emerald-400 text-gray-900 font-medium rounded-xl border border-white/10 shadow-lg transition-all duration-200 hover:shadow-teal-400/25 hover:scale-[1.02] disabled:hover:scale-100 flex items-center gap-2"
             >
               {isConnecting ? (
                 <div className="flex items-center justify-center gap-2">

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -15,15 +15,43 @@ export const defaultOpenGraphImage = {
 
 export const defaultTwitterImage = "/twitter-image.png";
 
+// Primary keywords (highest search volume)
+export const primaryKeywords = [
+  "learn solana",
+  "solana course",
+  "solana tutorial",
+  "solana development course",
+  "learn solana development",
+];
+
+// Secondary keywords (medium volume, high intent)
+export const secondaryKeywords = [
+  "solana developer tutorial",
+  "solana programming",
+  "solana blockchain course",
+  "solana smart contracts",
+  "anchor framework tutorial",
+  "rust solana",
+  "solana web3 course",
+  "free solana course",
+];
+
+// Long-tail keywords (lower volume, high conversion)
+export const longTailKeywords = [
+  "how to learn solana",
+  "solana development for beginners",
+  "best solana course",
+  "solana coding challenges",
+  "solana games to learn",
+  "solana developer bootcamp",
+  "build on solana",
+];
+
+// Combined for metadata
 export const courseKeywords = [
-  "Learn Solana",
-  "Learn Solana development",
-  "Solana Course",
-  "Web3 Course",
-  "Rust smart contracts",
-  "Anchor framework",
-  "Web3 education",
-  "Solana games",
+  ...primaryKeywords,
+  ...secondaryKeywords,
+  ...longTailKeywords,
 ];
 
 export const createCanonical = (path: string) => {


### PR DESCRIPTION
This pull request makes significant improvements to the site's SEO, metadata, and homepage content, focusing on presenting learn.sol as a free, comprehensive Solana development course. Major changes include enhanced metadata for all main pages, improved structured data for search engines, and rewritten homepage and section copy to better communicate the site's value proposition to learners and search engines.

### SEO and Metadata Enhancements

* All main pages (`app/page.tsx`, `app/modules/page.tsx`, `app/games/page.tsx`, `app/challenges/page.tsx`, `app/projects/page.tsx`) now include expanded, targeted `keywords` arrays and more descriptive titles and descriptions to improve discoverability in search engines. [[1]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L10-R25) [[2]](diffhunk://#diff-74bee3d84c78b2509653db473b487564c9077c29a6aaf233c38cdd82dcf886dcL9-R29) [[3]](diffhunk://#diff-54d306aee783c8b3499df577f6680d23fa8d7bb810c7efd50a18f32c4d0a72b6L9-R26) [[4]](diffhunk://#diff-bdc59d3c0af8074803248ffc87ab022adb9b36cee3018a97e7c5eae47d97bb0dL9-R27) [[5]](diffhunk://#diff-44af416e721f1b1fcc4a7bcdb204158cf1fafcbf4b1a6cbe99f069cf4cdca411L9-R27)
* The root metadata in `app/layout.tsx` has been rewritten for clarity and SEO, including updated titles, descriptions, OpenGraph, and Twitter card information. The site is now categorized as "education" instead of "technology". [[1]](diffhunk://#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030bL61-R114) [[2]](diffhunk://#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030bL86-R125) [[3]](diffhunk://#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030bL102-R139)

### Structured Data Improvements

* Added new JSON-LD structured data blocks for Organization, Course, and Website to `app/layout.tsx`, helping Google and other search engines better understand the site's educational focus and offerings. [[1]](diffhunk://#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030bL35-R40) [[2]](diffhunk://#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030bR51-R85) [[3]](diffhunk://#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030bR163-R176)

### Homepage and Section Copy Updates

* The homepage and the "Learn Solana" section (`components/home/learn-solana-section.tsx`, `app/home-page.client.tsx`) have been rewritten to emphasize the free Solana development course, interactive games, and coding challenges, with clearer calls to action and improved accessibility. [[1]](diffhunk://#diff-636863d76c3e775624c2908e20250dfae7f0d6374ec17be949c41f169f7dac9cL20-R79) [[2]](diffhunk://#diff-38c6bd6a3609a42d7aaac777a9196c4181a411aa5f75b46711ef3481bb9f0e01L38-R51)

### Visual and Style Adjustments

* Gradient backgrounds throughout the site now use a consistent `bg-linear-to-br` class for improved visual style and maintainability. [[1]](diffhunk://#diff-636863d76c3e775624c2908e20250dfae7f0d6374ec17be949c41f169f7dac9cL20-R79) [[2]](diffhunk://#diff-4b27a734c0f7bee4837c34af5279683acd8bc8b040ada15ff336c7ec9a4ae778L123-R123) [[3]](diffhunk://#diff-4b27a734c0f7bee4837c34af5279683acd8bc8b040ada15ff336c7ec9a4ae778L150-R150)

### Sitemap Improvements

* The sitemap (`app/sitemap.ts`) now assigns priorities and change frequencies to routes, includes challenge tracks, and better communicates page importance to search engines for more effective crawling and indexing. [[1]](diffhunk://#diff-68c980f6cc36311701d8a04a11d2bd6363c91b7199c333615e4d33b26f2e20e1L5-R31) [[2]](diffhunk://#diff-68c980f6cc36311701d8a04a11d2bd6363c91b7199c333615e4d33b26f2e20e1L36-R47) [[3]](diffhunk://#diff-68c980f6cc36311701d8a04a11d2bd6363c91b7199c333615e4d33b26f2e20e1R64-R84)