### PR TITLE
feat: add "Back to Home" link to Challenges and Games pages

### DIFF
--- a/app/challenges/challenges-page.client.tsx
+++ b/app/challenges/challenges-page.client.tsx
@@ -37,6 +37,12 @@ export function ChallengesPageClient() {
       <div className="absolute inset-0" style={{ background: backgroundStyle }} />
       <div className="relative z-10 flex min-h-screen w-full justify-center px-6 py-16 md:px-10">
         <div className="flex w-full max-w-5xl flex-col gap-14">
+          <Link
+            href="/"
+            className="inline-flex items-center gap-2 rounded-lg bg-zinc-900/60 px-4 py-2 text-sm text-zinc-300 transition hover:bg-zinc-900 w-fit"
+          >
+            ← Back to Home
+          </Link>
           <header className="space-y-8">
             <div className="space-y-4">
               <div className="text-xs tracking-[0.25em] text-zinc-500">[CHALLENGES]</div>
@@ -99,9 +105,7 @@ export function ChallengesPageClient() {
                     <li><span className="text-zinc-300">Days 29–30:</span> Consolidation, audit mindset, mini on-chain refactor.</li>
                   </ul>
                 </div>
-                <div className="flex items-center justify-center rounded-2xl border border-dashed border-white/10 bg-white/[0.03] px-6 py-8 text-center text-xs text-zinc-500">
-                  Full interactive challenge (daily prompts, tests, progress sync) is coming soon.
-                </div>
+             
               </div>
             </div>
           </article>

--- a/app/games/games-page.client.tsx
+++ b/app/games/games-page.client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useMemo, useRef, useState, useCallback } from "react";
+import Link from "next/link";
 import { useAutoRegisterUser } from "@/hooks/use-auto-register-user";
 import { authFetch } from "@/lib/auth/authFetch";
 import { useWeb3AuthUser, useWeb3Auth } from "@web3auth/modal/react";
@@ -217,6 +218,12 @@ export function GamesPageClient() {
   return (
     <main className="min-h-screen bg-[#0a0a0a] text-zinc-100">
       <div className="mx-auto max-w-4xl px-4 py-16">
+        <Link
+          href="/"
+          className="mb-6 inline-flex items-center gap-2 rounded-lg bg-zinc-900/60 px-4 py-2 text-sm text-zinc-300 transition hover:bg-zinc-900"
+        >
+          ← Back to Home
+        </Link>
         <div ref={containerRef}>
           <div className="mb-10">
             <div className="text-xs tracking-[0.25em] text-zinc-400">


### PR DESCRIPTION
This pull request adds a navigational improvement to both the Challenges and Games pages by introducing a "Back to Home" link at the top of each page. Additionally, it removes the placeholder message about upcoming interactive challenge features from the Challenges page.

Navigation enhancements:

* Added a "← Back to Home" link to the top of the `ChallengesPageClient` and `GamesPageClient` components for improved user navigation. (`app/challenges/challenges-page.client.tsx`, [[1]](diffhunk://#diff-5a1018164337b7b506f99b5f894fe761dfaa16e5ae7d983123b41ce329573443R40-R45) (`app/games/games-page.client.tsx`, [[2]](diffhunk://#diff-ee076cdbdb9216f63682ec1bf686e132058e702a89bec7ddc436dd286aae9567R221-R226)
* Imported the `Link` component from `next/link` in `games-page.client.tsx` to support the new navigation link.

Content update:

* Removed the "Full interactive challenge is coming soon" placeholder from the Challenges page to clean up the UI. (`app/challenges/challenges-page.client.tsx`, [app/challenges/challenges-page.client.tsxL102-R108](diffhunk://#diff-5a1018164337b7b506f99b5f894fe761dfaa16e5ae7d983123b41ce329573443L102-R108))